### PR TITLE
Improve sidebar with collapsible submenu

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -6,13 +6,21 @@ import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Separator } from '@/components/ui/separator';
 import { Badge } from '@/components/ui/badge';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { 
-  Home, 
-  Building2, 
-  Users, 
+  Home,
+  Building2,
+  Users,
   Settings,
   Building,
   CheckSquare,
+  Shield,
+  ChevronDown,
   ChevronLeft,
   ChevronRight
 } from 'lucide-react';
@@ -23,6 +31,7 @@ export const Sidebar = () => {
   const navigate = useNavigate();
   const { selectedCompany } = useCompanyContext();
   const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isAdminOpen, setIsAdminOpen] = useState(false);
 
   const menuItems = [
     {
@@ -36,6 +45,14 @@ export const Sidebar = () => {
       path: '/tasks',
     },
     {
+      title: 'Configurações',
+      icon: Settings,
+      path: '/company-settings',
+    },
+  ];
+
+  const adminItems = [
+    {
       title: 'Usuários',
       icon: Users,
       path: '/users',
@@ -46,9 +63,9 @@ export const Sidebar = () => {
       path: '/departments',
     },
     {
-      title: 'Configurações',
-      icon: Settings,
-      path: '/company-settings',
+      title: 'Funções',
+      icon: Shield,
+      path: '/roles',
     },
   ];
 
@@ -98,7 +115,7 @@ export const Sidebar = () => {
           {menuItems.map((item) => {
             const Icon = item.icon;
             const isActive = location.pathname === item.path;
-            
+
             return (
               <Button
                 key={item.path}
@@ -114,6 +131,71 @@ export const Sidebar = () => {
               </Button>
             );
           })}
+
+          <Separator />
+
+          {isCollapsed ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant={adminItems.some((i) => i.path === location.pathname) ? 'default' : 'ghost'}
+                  className={cn('w-full justify-center px-2')}
+                >
+                  <Shield className="w-4 h-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent side="right" align="start">
+                {adminItems.map((item) => {
+                  const Icon = item.icon;
+                  return (
+                    <DropdownMenuItem
+                      key={item.path}
+                      onSelect={() => handleNavigation(item.path)}
+                    >
+                      <Icon className="mr-2 h-4 w-4" />
+                      {item.title}
+                    </DropdownMenuItem>
+                  );
+                })}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : (
+            <>
+              <Button
+                variant={adminItems.some((i) => i.path === location.pathname) ? 'default' : 'ghost'}
+                className="w-full justify-start gap-3"
+                onClick={() => setIsAdminOpen(!isAdminOpen)}
+              >
+                <Shield className="w-4 h-4" />
+                <span>Administração</span>
+                <ChevronDown
+                  className={cn(
+                    'ml-auto w-4 h-4 transition-transform',
+                    isAdminOpen && 'rotate-180'
+                  )}
+                />
+              </Button>
+              {isAdminOpen && (
+                <div className="ml-6 space-y-1">
+                  {adminItems.map((item) => {
+                    const Icon = item.icon;
+                    const isActive = location.pathname === item.path;
+                    return (
+                      <Button
+                        key={item.path}
+                        variant={isActive ? 'default' : 'ghost'}
+                        className="w-full justify-start gap-3"
+                        onClick={() => handleNavigation(item.path)}
+                      >
+                        <Icon className="w-4 h-4" />
+                        <span>{item.title}</span>
+                      </Button>
+                    );
+                  })}
+                </div>
+              )}
+            </>
+          )}
         </nav>
       </ScrollArea>
     </div>


### PR DESCRIPTION
## Summary
- add collapsible Administration submenu in the sidebar
- hide submenus until clicked and show inline when expanded

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68404a7066fc83259324c4a70ad3aab8